### PR TITLE
Update Stephen Wolfram blog feed URL to HTTPS

### DIFF
--- a/elfeed-feeds.el
+++ b/elfeed-feeds.el
@@ -5,7 +5,7 @@
         ("https://sachachua.com/blog/category/emacs-news/feed/" emacs)
         ("https://protesilaos.com/codelog.xml" emacs)
         ("https://geohot.github.io/blog/feed.xml" programming)
-        ("http://blog.stephenwolfram.com/feed/" science)
+        ("https://writings.stephenwolfram.com/feed/" science)
         ("https://vitalik.eth.limo/feed.xml" crypto)
         ("https://stephango.com/feed.xml" blogs)
         ("https://ranprieur.com/feed.php" blogs)))


### PR DESCRIPTION
## Summary
Updated the Stephen Wolfram blog feed URL to use the current HTTPS endpoint.

## Changes
- Changed Stephen Wolfram feed URL from `http://blog.stephenwolfram.com/feed/` to `https://writings.stephenwolfram.com/feed/`
  - Migrates from HTTP to HTTPS for improved security
  - Updates to the new domain where Stephen Wolfram's writings are now hosted

## Details
This change ensures the feed reader continues to properly subscribe to Stephen Wolfram's content at its current location while also benefiting from the security improvements of HTTPS.

https://claude.ai/code/session_01NFjLFnrVHbpzCCnnBrgEUp